### PR TITLE
Add reverse order option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ gist cli for gist.github.com, it could build a neat gist list in markdown format
 - gistly init --token 'your github token with gist access'
 - gistly index # this prints a markdown format gist index
 - gistly index --put # put the created gist index on the server
+- gistly index --reverse-order # reverse the index order
 - gistly link --gist-id 'gist id' # link to existing index gist
 - gistly unlink # unlink from linked index gist

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ program
   .command('index')
   .option('--no-footer', 'no footer promo link', false)
   .option('-p, --put', 'put the created gist index on the server', false)
+  .option('-r, --reverse-order', 'reverse the index order', false)
   .description('Create gist index')
   .action(async function (args) {
     const token = getConfig('token');
@@ -24,6 +25,7 @@ program
     }
     const options = {
       hasFooter: args.footer,
+      orderDirection: args.reverseOrder ? 'DESC' : 'ASC',
     };
     const txt = await makeIndex(token, options);
     console.info(txt);

--- a/src/makeindex.js
+++ b/src/makeindex.js
@@ -8,7 +8,7 @@ async function makeIndex(token, options) {
       viewer {
         login
         url
-        gists(first: 100, orderBy: { field: CREATED_AT, direction: ASC }) {
+        gists(first: 100, orderBy: { field: CREATED_AT, direction: ${options.orderDirection} }) {
           edges {
             node {
               isPublic


### PR DESCRIPTION
I've added the `--reverse-order` option.

This option for the index command to reverse gist index order.

Thank you!